### PR TITLE
authentification digest

### DIFF
--- a/api/auth.php
+++ b/api/auth.php
@@ -1,0 +1,59 @@
+<?php
+
+function auth_check($realm) {
+    if(isset($_SERVER['PHP_AUTH_DIGEST'])) {
+        $digest = $_SERVER['PHP_AUTH_DIGEST'];
+    } else if(isset($_SERVER['HTTP_AUTHENTICATION']) &&
+              strpos(strtolower($_SERVER['HTTP_AUTHENTICATION']), "digest") == 0) {
+        $digest = substr($_SERVER['HTTP_AUTHORIZATION'], 7);
+    }
+
+    if(!isset($digest)) {
+        return false;
+    }
+
+    // check digest string
+    $needed_parts = array('nonce'=>1, 'nc'=>1, 'cnonce'=>1, 'qop'=>1, 'username'=>1,'uri'=>1, 'response'=>1);
+    $data = array();
+    $keys = implode('|', array_keys($needed_parts));
+
+    preg_match_all('@('.$keys.')=(?:([\'"])([^\2]+?)\2|([^\s,]+))@', $digest, $matches, PREG_SET_ORDER);
+
+    foreach ($matches as $m) {
+        $data[$m[1]] = $m[3] ? $m[3] : $m[4];
+        unset($needed_parts[$m[1]]);
+    }
+
+    // digest string is not valid
+    if(count($needed_parts) > 0) {
+        return false;
+    }
+
+    // user found ?
+    $userMngr = new User();
+    $user = $userMngr->load(array('login'=>$data['username']));
+    if(!$user) {
+        return false;
+    }
+
+    // check credentials
+	$A1 = md5($data['username'] . ':' . $realm . ':' . $user->getPassword());
+	$A2 = md5($_SERVER['REQUEST_METHOD'].':'.$data['uri']);
+    $resp = md5($A1.':'.$data['nonce'].':'.$data['nc'].':'.$data['cnonce'].':'.$data['qop'].':'.$A2);
+
+    if($data['response'] != $resp) {
+        return false;
+    }
+
+    return $user;
+}
+
+function auth_request($realm) {
+    header("WWW-Authenticate: Digest realm=\"$realm\",qop=\"auth\",nonce=\"".uniqid()."\",opaque=\"".session_id()."\"");
+    header("HTTP/1.0 401 Unauthorized");
+    echo "{\"error\":{\"id\":\"2\",\"message\":\"login failed\"}}\n";
+
+    die();
+}
+
+?>

--- a/api/json.php
+++ b/api/json.php
@@ -16,20 +16,13 @@ $folders = $folderManager->populate('name');
 //recuperation de tous les flux 
 $allFeeds = $feedManager->getFeedsPerFolder();
 
-$user = new User();
-
-$login = $_REQUEST['login'];
-$password = $_REQUEST['password'];
-
-$return11 = $user->exist($login, $password);
-
 header('Cache-Control: no-cache, must-revalidate');
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Content-type: application/json');
 
 if(PLUGIN_ENABLED == 1)
 {
-    if($return11 != false)
+    if($myUser != false)
     {
         switch($_REQUEST['option'])
         {
@@ -179,4 +172,6 @@ else
     // Error#1: plugin disable
     echo "{\"error\":{\"id\":\"1\",\"message\":\"API disabled\"}}\n";
 }
+
 ?>
+

--- a/api/login.php
+++ b/api/login.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once('../../common.php');
+require_once('./constantAPI.php');
+require_once('./auth.php');
+
+
+$realm = $_SERVER['SERVER_NAME'];
+
+if(!$myUser && !($myUser = auth_check($realm))) {
+   auth_request($realm);
+}
+
+$_SESSION['currentUser'] = serialize($myUser);
+ 
+?>

--- a/api/logout.php
+++ b/api/logout.php
@@ -1,0 +1,13 @@
+<?php
+
+require_once('../../common.php');
+require_once('./auth.php');
+
+$_SESSION = array();
+session_unset();
+session_destroy();
+
+// force to "unregister" on client side
+auth_request($_SERVER['SERVER_NAME']);
+
+?>


### PR DESCRIPTION
remplace l'authentification en clair par une authentification digest:
- /login.php pour se connecter (retourne un cookie PHPSESSID)
- /logout.php pour se déconnecter (renvoi une erreur 401 pour "obliger" les navigateurs à se déconnecter)
- il n'est plus nécessaire de passer les paramètres login et password pour chaque requête de l'API
