### PR TITLE
nettoyage + développement pour support de LeedReader/Issue #63

### DIFF
--- a/api/json.php
+++ b/api/json.php
@@ -33,6 +33,8 @@ if(PLUGIN_ENABLED == 1)
         else
             $option = "";
     
+        $unreadOnly = FALSE;
+
         switch($option)
         {
 
@@ -175,9 +177,13 @@ if(PLUGIN_ENABLED == 1)
             
             break;
             
+            case "getUnreadFolders":
+		$unreadOnly = TRUE;
+            
             case "getFolders":
                 $tab = array();
                 $iTab = 0;
+                if (isset($_REQUEST['unreadOnly'])) $unreadOnly = $_REQUEST['unreadOnly'];
                 
                 $nbNoRead = $feedManager->countUnreadEvents();
                 
@@ -189,13 +195,14 @@ if(PLUGIN_ENABLED == 1)
                         
                         foreach($feeds as $title => $value)
                         {
-                            $allFeeds['folderMap'][$folder->getId()][$title]['nbNoRead'] = 0;
-                            foreach($nbNoRead as $title2 => $value2)
+			    $allFeeds['folderMap'][$folder->getId()][$title]['nbNoRead'] = 0;
+                            if (isset($nbNoRead[$title]))
                             {
-                                if($title == $title2)
-                                {
-                                    $allFeeds['folderMap'][$folder->getId()][$title]['nbNoRead'] = $value2;
-                                }
+                                $allFeeds['folderMap'][$folder->getId()][$title]['nbNoRead'] = $nbNoRead[$title]*1;
+                            }
+                            else
+                            {
+                                if ($unreadOnly) unset($allFeeds['folderMap'][$folder->getId()][$title]);
                             }
                         }
                         
@@ -209,6 +216,7 @@ if(PLUGIN_ENABLED == 1)
                 }
 
                 $jsonOutput = "{\"folders\":".json_encode($tab)."}\n";
+
             break;
             
             case "setFeedRead":


### PR DESCRIPTION
Suite au ticket LeedReader/Issue #63.

Je propose ce développement qui allège le traitement de getFolders (j'ai enlevé une boucle), et ajoute le support du mode qui ne charge pas les flux vide.

Comment l'utiliser :
- leed/plugins/api/json.php?option=getFolders
  renvoie les mêmes résultats que précédemment
- leed/plugins/api/json.php?option=getUnreadFolders
  et
  leed/plugins/api/json.php?option=getFolders&unreadOnly=1
  ne renvoient que les flux pour lesquels il existe au moins un élément non lus

D'après mes tests on gagne en taille de la réponse (évidemment) mais on a aussi un gain de performance intéressant au niveau du serveur.

Je n'ai toujours pas le SDK Android, donc ne peut pas encore toucher au code côté client…
