### PR TITLE
Gestion simplifiée du constantAPI.php

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,0 +1,1 @@
+constantAPI.php

--- a/api/constantAPI.php
+++ b/api/constantAPI.php
@@ -1,3 +1,0 @@
-<?php
-define('PLUGIN_ENABLED','0');
-?>

--- a/api/uninstall.php
+++ b/api/uninstall.php
@@ -1,9 +1,5 @@
 <?php
 
-$constant = "<?php
-define('PLUGIN_ENABLED','0');
-?>";
-
-file_put_contents('plugins/api/constantAPI.php', $constant);
+unlink( Plugin::path().'constantAPI.php' );
 
 ?>


### PR DESCRIPTION
- suppression du fichier constantAPI.php par défaut
- ajout d'un .gitignore pour éviter qu'il soit versionné
- gestion de la suppression du fichier lors de la désinstallation du plugin
